### PR TITLE
Add Home Assistant config flow setup for Alert2

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ Suggestions welcome! Start a [Discussion](https://github.com/redstone99/hass-ale
 
 1. We strongly recommend also installing the [Alert2 UI](https://github.com/redstone99/hass-alert2-ui) card which is a compact way to view and manage Alert2 alerts.
 
+### Home Assistant Config Flow Setup
+
+1. Go to the Home Assistant web interface.
+
+1. Click on "Configuration" in the sidebar.
+
+1. Click on "Integrations".
+
+1. Click the "+" button to add a new integration.
+
+1. Search for "Alert2" and select it.
+
+1. Follow the on-screen instructions to set up the Alert2 integration.
+
 ## Setup
 
 Setup is done through editing your `configuration.yaml` file.

--- a/custom_components/alert2/config_flow.py
+++ b/custom_components/alert2/config_flow.py
@@ -1,0 +1,49 @@
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv
+
+from . import DOMAIN
+
+class Alert2ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        return Alert2OptionsFlowHandler(config_entry)
+
+    async def async_step_user(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            return self.async_create_entry(title="Alert2", data=user_input)
+
+        data_schema = vol.Schema({
+            vol.Required("domain"): cv.string,
+            vol.Required("name"): cv.string,
+        })
+
+        return self.async_show_form(
+            step_id="user", data_schema=data_schema, errors=errors
+        )
+
+class Alert2OptionsFlowHandler(config_entries.OptionsFlow):
+    def __init__(self, config_entry):
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        return await self.async_step_user()
+
+    async def async_step_user(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        data_schema = vol.Schema({
+            vol.Required("domain"): cv.string,
+            vol.Required("name"): cv.string,
+        })
+
+        return self.async_show_form(
+            step_id="user", data_schema=data_schema, errors=errors
+        )

--- a/custom_components/alert2/manifest.json
+++ b/custom_components/alert2/manifest.json
@@ -4,5 +4,6 @@
     "documentation": "https://github.com/redstone99/hass-alert2",
     "codeowners": [],
     "version": "1.4",
-    "dependencies": [ ]
+    "dependencies": [ ],
+    "config_flow": true
 }


### PR DESCRIPTION
Add support for Home Assistant config flow setup for the Alert2 integration.

* **Add `config_flow.py`**: Create `custom_components/alert2/config_flow.py` to define the configuration flow, including `Alert2ConfigFlow` and `Alert2OptionsFlowHandler` classes.
* **Update `manifest.json`**: Add `"config_flow": true` to `custom_components/alert2/manifest.json`.
* **Update `README.md`**: Add instructions for setting up Alert2 using Home Assistant config flow.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/spencermamer/hass-alerts/pull/1?shareId=9435cda7-8d83-47e6-8666-1b4279c1531b).